### PR TITLE
Add sanity test workflow

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,18 @@
+name: Sanity Checks
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Swift
+        uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: "6.1"
+      - name: Run sanity tests
+        run: |
+          bash scripts/run_sanity_tests.sh

--- a/scripts/run_sanity_tests.sh
+++ b/scripts/run_sanity_tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Finds all Swift files under the repository and ensures they parse
+# using the Swift compiler front-end. This catches basic syntax errors
+# without requiring Xcode or iOS SDKs.
+
+status=0
+while IFS= read -r swift_file; do
+  echo "Parsing $swift_file"
+  if ! swift -frontend -parse "$swift_file" >/dev/null 2>&1; then
+    echo "Failed to parse $swift_file" >&2
+    status=1
+  fi
+done < <(find Jimmy -name '*.swift')
+
+exit $status


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to parse Swift sources
- script to parse all Swift files to catch syntax errors

## Testing
- `bash scripts/run_sanity_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fdf42ba748323b035305bfacd338b