### PR TITLE
Fix README collaboration link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to Jimmy
+
+Thanks for your interest in contributing! Please follow these guidelines to keep the project consistent:
+
+## Workflow
+
+1. Fork the repository and create your feature branch from `main`.
+2. Write clear commit messages and keep commits focused on a single change.
+3. Make sure the project builds before submitting a pull request.
+
+## Style
+
+- Use Swift 5.9+ and follow Swift standard formatting.
+- Keep files organized as described in `Jimmy/README.md`.
+
+## Communication
+
+Open an issue if you plan to work on a significant change or have questions. Pull requests are reviewed as time permits.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Jimmy/
 
 ## 🤝 Collaboration & Project Rules
 
-See [CURSOR_RULES.md](./CURSOR_RULES.md) for:
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for:
 - Collaboration guidelines
 - Tech stack
 - Ideal project structure


### PR DESCRIPTION
## Summary
- point to `CONTRIBUTING.md` instead of missing file
- add a simple contributing guide

## Testing
- `bash scripts/run_sanity_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fe1b8af3483238e506611b8aa6a20