### PR TITLE
Fix trailing prompt in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ This project is for personal use and educational purposes.
 
 ---
 
-**🎉 Ready to Use**: The main app is fully functional and ready for use. The lock-screen widget is implemented and ready for Xcode setup following the guide in `WIDGET_README.md`. 
+**🎉 Ready to Use**: The main app is fully functional and ready for use. The lock-screen widget is implemented and ready for Xcode setup following the guide in `WIDGET_README.md`.


### PR DESCRIPTION
## Summary
- trim any accidental prompt string from README
- ensure README ends with a newline

## Testing
- `git show HEAD:README.md | tail -c 1 | od -An -t x1`

------
https://chatgpt.com/codex/tasks/task_e_683fe1c4b8b0832393264ce21802de1c