### PR TITLE
Sync queue played status on bulk episode actions

### DIFF
--- a/Jimmy/ViewModels/EpisodeViewModel.swift
+++ b/Jimmy/ViewModels/EpisodeViewModel.swift
@@ -49,21 +49,31 @@ class EpisodeViewModel: ObservableObject {
     // MARK: - Batch Operations
     
     func markAllEpisodesAsPlayed(for podcastID: UUID) {
+        var affectedIDs = Set<UUID>()
         for i in episodes.indices {
             if episodes[i].podcastID == podcastID {
                 episodes[i].played = true
+                affectedIDs.insert(episodes[i].id)
             }
         }
         saveEpisodes()
+        if !affectedIDs.isEmpty {
+            QueueViewModel.shared.markEpisodesAsPlayed(withIDs: affectedIDs, played: true)
+        }
     }
-    
+
     func markAllEpisodesAsUnplayed(for podcastID: UUID) {
+        var affectedIDs = Set<UUID>()
         for i in episodes.indices {
             if episodes[i].podcastID == podcastID {
                 episodes[i].played = false
+                affectedIDs.insert(episodes[i].id)
             }
         }
         saveEpisodes()
+        if !affectedIDs.isEmpty {
+            QueueViewModel.shared.markEpisodesAsPlayed(withIDs: affectedIDs, played: false)
+        }
     }
     
     // MARK: - Persistence

--- a/Jimmy/ViewModels/QueueViewModel.swift
+++ b/Jimmy/ViewModels/QueueViewModel.swift
@@ -176,10 +176,10 @@ class QueueViewModel: ObservableObject {
         saveQueue()
     }
     
-    func markEpisodesAsPlayed(withIDs ids: Set<UUID>) {
+    func markEpisodesAsPlayed(withIDs ids: Set<UUID>, played: Bool = true) {
         for i in queue.indices {
             if ids.contains(queue[i].id) {
-                queue[i].played = true
+                queue[i].played = played
             }
         }
         saveQueue()


### PR DESCRIPTION
## Summary
- collect IDs for bulk played/unplayed actions
- update queued episodes using new `markEpisodesAsPlayed(withIDs:played:)`
- add `played:` parameter to queue method

## Testing
- `scripts/run_sanity_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fe1e409d083239e3053d645b5015a