### PR TITLE
Replace invalid symbol in PodcastDetailView

### DIFF
--- a/Jimmy/Views/PodcastDetailView.swift
+++ b/Jimmy/Views/PodcastDetailView.swift
@@ -213,7 +213,7 @@ struct PodcastDetailHeaderView: View {
                         )
                     )
                     .overlay(
-                        Image(systemName: "방송") // Using a generic podcast icon (Korean for broadcast)
+                        Image(systemName: "waveform.circle.fill") // Using a generic podcast icon (Korean for broadcast)
                             .font(.system(size: 40))
                             .foregroundColor(.secondary.opacity(0.8))
                     )


### PR DESCRIPTION
## Summary
- use a valid SF Symbol in PodcastDetailView placeholder artwork

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fe1fad66c832399ae50c5551a2c8c