### PR TITLE
Fix podcast artwork detection

### DIFF
--- a/Jimmy/ARTWORK_USAGE_GUIDELINES.md
+++ b/Jimmy/ARTWORK_USAGE_GUIDELINES.md
@@ -71,8 +71,8 @@ Each time you visit a podcast page, the artwork will be automatically updated if
 ## Common Issues & Solutions
 
 ### Issue: Show displays first episode's artwork
-**Cause**: RSS feed was parsed before artwork enhancement, or feed has complex artwork structure
-**Solution**: Use "Fix Podcast Artwork" button in Settings
+**Cause**: Older versions of the RSS parser treated the first episode's artwork as the podcast artwork
+**Solution**: Update Jimmy to the latest version and then use the "Fix Podcast Artwork" button in Settings
 
 ### Issue: Episode shows podcast artwork instead of episode-specific artwork
 **Cause**: Episode doesn't have its own artwork in the RSS feed

--- a/Jimmy/Utilities/RSSParser.swift
+++ b/Jimmy/Utilities/RSSParser.swift
@@ -55,19 +55,19 @@ class RSSParser: NSObject, XMLParserDelegate {
         if parsingItem && elementName == "enclosure" {
             currentAudioURL = attributeDict["url"] ?? ""
         }
-        if parsingChannel && (elementName == "itunes:image" || elementName == "image") {
+        if parsingChannel && !parsingItem && (elementName == "itunes:image" || elementName == "image") {
             if let url = attributeDict["href"] ?? attributeDict["url"] {
                 print("🎨 Found channel artwork via \(elementName): \(url)")
                 podcastArtworkURL = url
             }
         }
-        if parsingChannel && (elementName == "media:thumbnail" || elementName == "thumbnail") {
+        if parsingChannel && !parsingItem && (elementName == "media:thumbnail" || elementName == "thumbnail") {
             if let url = attributeDict["url"] {
                 print("🎨 Found channel artwork via \(elementName): \(url)")
                 podcastArtworkURL = url
             }
         }
-        if parsingChannel && elementName == "url" && currentElementName == "image" {
+        if parsingChannel && !parsingItem && elementName == "url" && currentElementName == "image" {
             // This will be handled in foundCharacters
         }
         if parsingItem && (elementName == "itunes:image" || elementName == "image") {


### PR DESCRIPTION
## Summary
- correctly ignore episode artwork when parsing RSS
- update troubleshooting docs about show artwork problems

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_683ff22adc74832391791d12110c1e57