### PR TITLE
Refine queue logic for unique episodes

### DIFF
--- a/Jimmy/ViewModels/QueueViewModel.swift
+++ b/Jimmy/ViewModels/QueueViewModel.swift
@@ -13,14 +13,18 @@ class QueueViewModel: ObservableObject {
     // MARK: - Basic Queue Operations
     
     func addToQueue(_ episode: Episode) {
-        // Allow duplicates - users might want the same episode multiple times
+        // Prevent duplicate episodes in the queue
+        guard !queue.contains(where: { $0.id == episode.id }) else { return }
         queue.append(episode)
         saveQueue()
     }
     
     func addToTopOfQueue(_ episode: Episode) {
-        // Allow duplicates - don't remove existing instances
-        
+        // Remove existing instance to avoid duplicates
+        if let existingIndex = queue.firstIndex(where: { $0.id == episode.id }) {
+            queue.remove(at: existingIndex)
+        }
+
         // If there's a currently playing episode (at position 0), insert at position 1
         // Otherwise, insert at position 0
         let insertIndex = (queue.isEmpty || AudioPlayerService.shared.currentEpisode == nil) ? 0 : 1
@@ -83,52 +87,58 @@ class QueueViewModel: ObservableObject {
     /// Play an episode from the library - moves current playing episode to second place
     func playEpisodeFromLibrary(_ episode: Episode) {
         let audioPlayer = AudioPlayerService.shared
-        
-        // Allow duplicates - don't remove existing instances from queue
-        
+
+        // Remove any existing instance of this episode to keep the queue unique
+        queue.removeAll { $0.id == episode.id }
+
         // If there's currently a playing episode, move it to second position
         if let currentEpisode = audioPlayer.currentEpisode {
             // Only remove the current episode if it's at position 0
             if !queue.isEmpty && queue[0].id == currentEpisode.id {
                 queue.removeFirst()
             }
-            
+
             // Insert new episode at position 0
             queue.insert(episode, at: 0)
-            
+
             // Insert previous episode at position 1
             queue.insert(currentEpisode, at: 1)
         } else {
             // No current episode, just add to front
             queue.insert(episode, at: 0)
         }
-        
+
         // Start playing the new episode
         audioPlayer.loadEpisode(episode)
         audioPlayer.play()
-        
+
         saveQueue()
     }
     
     /// Play an episode from the queue - removes all episodes above it
     func playEpisodeFromQueue(_ episode: Episode) {
         guard let episodeIndex = queue.firstIndex(where: { $0.id == episode.id }) else { return }
-        
+
         // If it's already at position 0, just play it
         if episodeIndex == 0 {
             AudioPlayerService.shared.loadEpisode(episode)
             AudioPlayerService.shared.play()
             return
         }
-        
+
         // Remove all episodes above the selected episode (0 to episodeIndex-1)
         queue.removeFirst(episodeIndex)
-        
-        // Now the selected episode should be at position 0
+
+        // Remove any remaining duplicates of this episode
+        queue.removeAll { $0.id == episode.id }
+
+        // Insert the selected episode at the top
+        queue.insert(episode, at: 0)
+
         // Start playing it
         AudioPlayerService.shared.loadEpisode(episode)
         AudioPlayerService.shared.play()
-        
+
         saveQueue()
     }
     
@@ -136,39 +146,40 @@ class QueueViewModel: ObservableObject {
     func playEpisodeFromQueue(at index: Int) {
         guard index < queue.count else { return }
         let episode = queue[index]
-        
+
         // If it's already at position 0, just play it
         if index == 0 {
             AudioPlayerService.shared.loadEpisode(episode)
             AudioPlayerService.shared.play()
             return
         }
-        
+
         // Remove all episodes above the selected episode (0 to index-1)
         queue.removeFirst(index)
-        
-        // Now the selected episode should be at position 0
+
+        // Remove any remaining duplicates of this episode
+        queue.removeAll { $0.id == episode.id }
+
+        // Insert the selected episode at the top
+        queue.insert(episode, at: 0)
+
         // Start playing it
         AudioPlayerService.shared.loadEpisode(episode)
         AudioPlayerService.shared.play()
-        
+
         saveQueue()
     }
     
     /// Ensure the currently playing episode is at the top of the queue
     func syncCurrentEpisodeWithQueue() {
         guard let currentEpisode = AudioPlayerService.shared.currentEpisode else { return }
-        
-        // Only ensure position 0 has the current episode, allow duplicates elsewhere
-        if queue.isEmpty || queue[0].id != currentEpisode.id {
-            // Remove current episode only if it's at position 0 and different
-            if !queue.isEmpty {
-                queue.removeFirst()
-            }
-            // Insert current episode at position 0
-            queue.insert(currentEpisode, at: 0)
-            saveQueue()
-        }
+
+        // Remove any existing copies of the current episode
+        queue.removeAll { $0.id == currentEpisode.id }
+
+        // Ensure the current episode is at the front of the queue
+        queue.insert(currentEpisode, at: 0)
+        saveQueue()
     }
     
     // MARK: - Existing Functions (kept for compatibility)


### PR DESCRIPTION
## Summary
- prevent duplicate episodes when adding to queue
- avoid duplicates for play next and play from library actions
- ensure currently playing episode remains unique in queue

## Testing
- `./scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ff69ce67c832389c5c765406559d2