### PR TITLE
Implement Discover recommendations

### DIFF
--- a/Jimmy/ContentView.swift
+++ b/Jimmy/ContentView.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
                     // Show only the selected tab content
                     if selectedTab == 0 {
                         NavigationView {
-                            PodcastSearchView()
+                            DiscoverView()
                         }
                         .transition(.opacity.combined(with: .scale(scale: 0.95)))
                     } else if selectedTab == 1 {

--- a/Jimmy/Services/RecommendationService.swift
+++ b/Jimmy/Services/RecommendationService.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+class RecommendationService {
+    static let shared = RecommendationService()
+    private init() {}
+
+    /// Fetch recommended podcasts based on current subscriptions using the iTunes Search API.
+    /// - Parameters:
+    ///   - podcasts: Subscribed podcasts to base recommendations on.
+    ///   - completion: Callback with array of search results.
+    func getRecommendations(basedOn podcasts: [Podcast], completion: @escaping ([PodcastSearchResult]) -> Void) {
+        guard !podcasts.isEmpty else {
+            completion([])
+            return
+        }
+
+        let subscribedFeeds = Set(podcasts.map { $0.feedURL })
+        var aggregated: [PodcastSearchResult] = []
+        let group = DispatchGroup()
+
+        // Limit to avoid excessive requests
+        for podcast in podcasts.prefix(5) {
+            group.enter()
+            let query = podcast.author
+            iTunesSearchService.shared.searchPodcasts(query: query) { results in
+                let filtered = results.filter { !subscribedFeeds.contains($0.feedURL) }
+                aggregated.append(contentsOf: filtered)
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            var seen: Set<URL> = []
+            let unique = aggregated.filter { result in
+                if seen.contains(result.feedURL) { return false }
+                seen.insert(result.feedURL)
+                return true
+            }
+            completion(Array(unique.prefix(50)))
+        }
+    }
+}

--- a/Jimmy/Views/DiscoverView.swift
+++ b/Jimmy/Views/DiscoverView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct DiscoverView: View {
+    @State private var recommended: [PodcastSearchResult] = []
+    @State private var isLoading = true
+    @State private var subscribed: [Podcast] = []
+    @State private var showingSubscriptionAlert = false
+    @State private var subscriptionMessage = ""
+
+    var body: some View {
+        List {
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView("Loading recommendations...")
+                        .progressViewStyle(CircularProgressViewStyle())
+                    Spacer()
+                }
+            } else if recommended.isEmpty {
+                VStack(spacing: 16) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 48))
+                        .foregroundColor(.gray)
+                    Text("No recommendations yet")
+                        .font(.headline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 40)
+            } else {
+                ForEach(recommended) { result in
+                    NavigationLink(destination: SearchResultDetailView(result: result)) {
+                        SearchResultRow(
+                            result: result,
+                            isSubscribed: isSubscribed(result)
+                        ) {
+                            // navigation handled by NavigationLink
+                        } onSubscribe: {
+                            subscribe(to: result)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle("Discover")
+        .onAppear {
+            loadData()
+        }
+        .alert("Subscription", isPresented: $showingSubscriptionAlert) {
+            Button("OK") { }
+        } message: {
+            Text(subscriptionMessage)
+        }
+    }
+
+    private func loadData() {
+        subscribed = PodcastService.shared.loadPodcasts()
+        isLoading = true
+        RecommendationService.shared.getRecommendations(basedOn: subscribed) { results in
+            recommended = results
+            isLoading = false
+        }
+    }
+
+    private func isSubscribed(_ result: PodcastSearchResult) -> Bool {
+        subscribed.contains { $0.feedURL == result.feedURL }
+    }
+
+    private func subscribe(to result: PodcastSearchResult) {
+        if isSubscribed(result) {
+            subscriptionMessage = "You're already subscribed to \(result.title)"
+            showingSubscriptionAlert = true
+            return
+        }
+
+        subscribed.append(result.toPodcast())
+        PodcastService.shared.savePodcasts(subscribed)
+        subscriptionMessage = "Successfully subscribed to \(result.title)"
+        showingSubscriptionAlert = true
+    }
+}
+
+#Preview {
+    NavigationView {
+        DiscoverView()
+    }
+}


### PR DESCRIPTION
## Summary
- add a recommendation service that uses the iTunes Search API
- implement `DiscoverView` to show recommended podcasts based on current subscriptions
- display `DiscoverView` in the first tab

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683ff6b8a20483239b16b0b108746634