### PR TITLE
Remove stray JimmyTests lines from project

### DIFF
--- a/Jimmy.xcodeproj/project.pbxproj
+++ b/Jimmy.xcodeproj/project.pbxproj
@@ -7,8 +7,7 @@
 	objects = {
 
 /* Begin PBXFileReference section */
-		D411ADBD2DE078AE00E1779D /* Jimmy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Jimmy.app; sourceTree = BUILT_PRODUCTS_DIR; };
-                                D51100092DE078AF00E1779D /* JimmyTests.xctest */
+               D411ADBD2DE078AE00E1779D /* Jimmy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Jimmy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -105,9 +104,8 @@
 			packageProductDependencies = (
 			);
 			productName = Jimmy;
-			productReference = D411ADBD2DE078AE00E1779D /* Jimmy.app */;
-                                D51100092DE078AF00E1779D /* JimmyTests.xctest */
-			productType = "com.apple.product-type.application";
+                       productReference = D411ADBD2DE078AE00E1779D /* Jimmy.app */;
+                       productType = "com.apple.product-type.application";
 		};
                 D51100052DE078AF00E1779D /* JimmyTests */ = {
                         isa = PBXNativeTarget;


### PR DESCRIPTION
## Summary
- clean up `project.pbxproj` by removing an orphan `JimmyTests.xctest` reference
- ensure the project parses via `plutil -lint`

## Testing
- `plutil -lint -- Jimmy.xcodeproj/project.pbxproj`


------
https://chatgpt.com/codex/tasks/task_e_684038f9b5648323b70632cc5114c0f4