### PR TITLE
Enable row swipe actions in library episode view

### DIFF
--- a/Jimmy/Views/LibraryView.swift
+++ b/Jimmy/Views/LibraryView.swift
@@ -940,6 +940,20 @@ struct EpisodeLibraryRowView: View {
             .padding(.vertical, 12)
             .background(Color(.systemBackground))
             .opacity(episode.played ? 0.6 : 1.0)
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                Button(action: onAddToQueue) {
+                    Label("Add to Queue", systemImage: "plus.circle")
+                }
+
+                Button(action: {
+                    onMarkAsPlayed(!episode.played)
+                }) {
+                    Label(
+                        episode.played ? "Mark as Unplayed" : "Mark as Played",
+                        systemImage: episode.played ? "circle" : "checkmark.circle"
+                    )
+                }
+            }
             
             // Separator
             Divider()


### PR DESCRIPTION
## Summary
- allow library episode rows to support swipe gestures

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68404255368c83239320c0cd1953800c