### PR TITLE
Add audio file sharing import

### DIFF
--- a/Jimmy/Info.plist
+++ b/Jimmy/Info.plist
@@ -17,9 +17,22 @@
 			</array>
 		</dict>
 	</array>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
+        <key>UIBackgroundModes</key>
+        <array>
+                <string>audio</string>
+        </array>
+        <key>CFBundleDocumentTypes</key>
+        <array>
+                <dict>
+                        <key>CFBundleTypeName</key>
+                        <string>Audio File</string>
+                        <key>LSHandlerRank</key>
+                        <string>Owner</string>
+                        <key>LSItemContentTypes</key>
+                        <array>
+                                <string>public.audio</string>
+                        </array>
+                </dict>
+        </array>
 </dict>
 </plist>

--- a/Jimmy/JimmyApp.swift
+++ b/Jimmy/JimmyApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 @main
 struct JimmyApp: App {
@@ -26,6 +27,15 @@ struct JimmyApp: App {
     }
     
     private func handleURL(_ url: URL) {
+        // If a local audio file was shared to the app, import it
+        if url.isFileURL {
+            if let type = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType,
+               type.conforms(to: .audio) {
+                _ = SharedAudioImporter.shared.importFile(from: url)
+            }
+            return
+        }
+
         // Handle jimmy://import?url=PODCAST_URL
         guard url.scheme == "jimmy",
               url.host == "import" else {

--- a/Jimmy/Services/SharedAudioImporter.swift
+++ b/Jimmy/Services/SharedAudioImporter.swift
@@ -1,0 +1,54 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// Handles importing audio files shared to the app
+class SharedAudioImporter {
+    static let shared = SharedAudioImporter()
+
+    private let fileManager = FileManager.default
+    private let baseDirectory: URL
+
+    private init() {
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        baseDirectory = documents.appendingPathComponent("SharedAudio")
+        if !fileManager.fileExists(atPath: baseDirectory.path) {
+            try? fileManager.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
+        }
+    }
+
+    /// Imports a shared audio file and returns the created Episode
+    @discardableResult
+    func importFile(from url: URL) -> Episode? {
+        let filename = url.lastPathComponent
+        let folderURL = baseDirectory.appendingPathComponent(UUID().uuidString)
+        do {
+            try fileManager.createDirectory(at: folderURL, withIntermediateDirectories: true)
+            let destURL = folderURL.appendingPathComponent(filename)
+            if fileManager.fileExists(atPath: destURL.path) {
+                try fileManager.removeItem(at: destURL)
+            }
+            try fileManager.copyItem(at: url, to: destURL)
+
+            let episode = Episode(
+                id: UUID(),
+                title: url.deletingPathExtension().lastPathComponent,
+                artworkURL: nil,
+                audioURL: destURL,
+                description: nil,
+                played: false,
+                podcastID: nil,
+                publishedDate: Date(),
+                localFileURL: destURL,
+                playbackPosition: 0
+            )
+
+            EpisodeViewModel.shared.addEpisodes([episode])
+            QueueViewModel.shared.addToQueue(episode)
+            return episode
+        } catch {
+            print("❌ Failed to import shared audio: \(error)")
+            return nil
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- accept audio files shared to the app
- store shared audio in a new `SharedAudio` directory and add an episode to the queue
- update Info.plist document types to support `public.audio`

## Testing
- `./scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68405a7fc0b08323945448f1a9af28a6