### PR TITLE
Fix loading screen timing

### DIFF
--- a/Jimmy/ContentView.swift
+++ b/Jimmy/ContentView.swift
@@ -75,9 +75,21 @@ struct ContentView: View {
                     .transition(.opacity)
             }
         }
+        .onAppear {
+            // Ensure the loading screen is visible immediately on launch
+            showLoadingScreen = true
+        }
         .onChange(of: updateService.isUpdating) { updating in
             withAnimation(.easeInOut) {
                 showLoadingScreen = updating
+            }
+        }
+        .onChange(of: updateService.updateProgress) { progress in
+            // Hide the loading screen as soon as some progress is made
+            if progress > 0 {
+                withAnimation(.easeInOut) {
+                    showLoadingScreen = false
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- trigger loading screen right away using `.onAppear`
- dismiss loading once any progress occurs during updates

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68405cfffb048323910e5762200b450f