### PR TITLE
Make discover view pop with gradients

### DIFF
--- a/Jimmy/Views/PodcastSearchView.swift
+++ b/Jimmy/Views/PodcastSearchView.swift
@@ -269,7 +269,27 @@ struct SearchResultRow: View {
     let isSubscribed: Bool
     let onTap: () -> Void
     let onSubscribe: () -> Void
-    
+
+    private static let colorPairs: [(Color, Color)] = [
+        (.pink, .orange),
+        (.purple, .blue),
+        (.green, .teal),
+        (.yellow, .orange),
+        (.mint, .green),
+        (.cyan, .indigo),
+        (.red, .pink),
+        (.orange, .pink)
+    ]
+
+    private var gradient: LinearGradient {
+        let pair = Self.colorPairs[abs(result.id) % Self.colorPairs.count]
+        return LinearGradient(
+            colors: [pair.0.opacity(0.1), pair.1.opacity(0.1)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
     var body: some View {
         Button(action: onTap) {
             HStack(alignment: .top, spacing: 12) {
@@ -311,7 +331,10 @@ struct SearchResultRow: View {
                 }
                 .buttonStyle(.plain)
             }
+            .padding(8)
+            .background(gradient)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
         }
         .buttonStyle(.plain)
     }
-} 
+}

--- a/Jimmy/Views/RecommendedPodcastItem.swift
+++ b/Jimmy/Views/RecommendedPodcastItem.swift
@@ -5,6 +5,27 @@ struct RecommendedPodcastItem: View {
     let isSubscribed: Bool
     let onSubscribe: () -> Void
 
+    /// Gradient palette for dynamic backgrounds
+    private static let colorPairs: [(Color, Color)] = [
+        (.pink, .orange),
+        (.purple, .blue),
+        (.green, .teal),
+        (.yellow, .orange),
+        (.mint, .green),
+        (.cyan, .indigo),
+        (.red, .pink),
+        (.orange, .pink)
+    ]
+
+    private var gradient: LinearGradient {
+        let pair = Self.colorPairs[abs(result.id) % Self.colorPairs.count]
+        return LinearGradient(
+            colors: [pair.0.opacity(0.2), pair.1.opacity(0.2)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
     var body: some View {
         VStack(spacing: 8) {
             PodcastArtworkView(
@@ -37,6 +58,10 @@ struct RecommendedPodcastItem: View {
             }
             .disabled(isSubscribed)
         }
+        .padding(8)
+        .background(gradient)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
     }
 }
 


### PR DESCRIPTION
## Summary
- add playful gradients to `RecommendedPodcastItem`
- stylize `SearchResultRow` with subtle gradient backgrounds

## Testing
- `scripts/run_sanity_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684060e5ba788323a5ce2f36c5b8aa91