### PR TITLE
Fix CarPlay queue subtitle

### DIFF
--- a/Jimmy/CarPlay/CarPlayManager.swift
+++ b/Jimmy/CarPlay/CarPlayManager.swift
@@ -27,6 +27,11 @@ final class CarPlayManager: NSObject {
     func reloadData() {
         MPPlayableContentManager.shared().reloadData()
     }
+
+    /// Helper to retrieve the podcast associated with an episode
+    private func getPodcast(for episode: Episode) -> Podcast? {
+        return PodcastService.shared.loadPodcasts().first { $0.id == episode.podcastID }
+    }
 }
 
 extension CarPlayManager: MPPlayableContentDelegate {
@@ -57,7 +62,7 @@ extension CarPlayManager: MPPlayableContentDataSource {
             let episode = QueueViewModel.shared.queue[indexPath[1]]
             let item = MPContentItem(identifier: episode.id.uuidString)
             item.title = episode.title
-            item.subtitle = episode.podcastTitle
+            item.subtitle = getPodcast(for: episode)?.title
             item.isContainer = false
             item.isPlayable = true
             return item


### PR DESCRIPTION
## Summary
- show podcast title in CarPlay queue items
- add helper to fetch podcast for a given episode

## Testing
- `./scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68412c805f608323b84fd12c69fa28a0