### PR TITLE
Improve Discover page with genre sections

### DIFF
--- a/Jimmy/Views/DiscoverGenreSectionView.swift
+++ b/Jimmy/Views/DiscoverGenreSectionView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct DiscoverGenreSectionView: View {
+    let genre: String
+    let results: [PodcastSearchResult]
+    let isSubscribed: (PodcastSearchResult) -> Bool
+    let onSubscribe: (PodcastSearchResult) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(genre)
+                .font(.title2.bold())
+                .padding(.horizontal)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 16) {
+                    ForEach(results) { result in
+                        NavigationLink(destination: SearchResultDetailView(result: result)) {
+                            LargeRecommendedPodcastItem(
+                                result: result,
+                                isSubscribed: isSubscribed(result),
+                                onSubscribe: { onSubscribe(result) }
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+}
+
+#Preview {
+    DiscoverGenreSectionView(
+        genre: "News",
+        results: [
+            PodcastSearchResult(
+                id: 1,
+                title: "Sample Podcast",
+                author: "Author",
+                feedURL: URL(string: "https://example.com/feed")!,
+                artworkURL: nil,
+                description: "",
+                genre: "News",
+                trackCount: 0
+            )
+        ],
+        isSubscribed: { _ in false },
+        onSubscribe: { _ in }
+    )
+}

--- a/Jimmy/Views/DiscoverView.swift
+++ b/Jimmy/Views/DiscoverView.swift
@@ -11,9 +11,9 @@ struct DiscoverView: View {
     @State private var isSearching = false
     @State private var lastSearchText = ""
 
-    private let columns = [
-        GridItem(.adaptive(minimum: 150), spacing: 16)
-    ]
+    private var groupedRecommended: [String: [PodcastSearchResult]] {
+        Dictionary(grouping: recommended, by: { $0.genre })
+    }
 
     var body: some View {
         Group {
@@ -77,19 +77,19 @@ struct DiscoverView: View {
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 40)
                     } else {
-                        LazyVGrid(columns: columns, spacing: 20) {
-                            ForEach(recommended) { result in
-                                NavigationLink(destination: SearchResultDetailView(result: result)) {
-                                    RecommendedPodcastItem(
-                                        result: result,
-                                        isSubscribed: isSubscribed(result),
-                                        onSubscribe: { subscribe(to: result) }
+                        VStack(alignment: .leading, spacing: 32) {
+                            ForEach(groupedRecommended.keys.sorted(), id: \.self) { genre in
+                                if let items = groupedRecommended[genre] {
+                                    DiscoverGenreSectionView(
+                                        genre: genre,
+                                        results: items,
+                                        isSubscribed: isSubscribed,
+                                        onSubscribe: { subscribe(to: $0) }
                                     )
                                 }
-                                .buttonStyle(.plain)
                             }
                         }
-                        .padding()
+                        .padding(.vertical)
                     }
                 }
             }
@@ -114,6 +114,15 @@ struct DiscoverView: View {
         } message: {
             Text(subscriptionMessage)
         }
+        .background(
+            RadialGradient(
+                gradient: Gradient(colors: [Color.accentColor.opacity(0.05), Color(.systemBackground)]),
+                center: .topLeading,
+                startRadius: 100,
+                endRadius: 500
+            )
+            .ignoresSafeArea()
+        )
     }
 
     private func loadData() {

--- a/Jimmy/Views/LargeRecommendedPodcastItem.swift
+++ b/Jimmy/Views/LargeRecommendedPodcastItem.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct LargeRecommendedPodcastItem: View {
+    let result: PodcastSearchResult
+    let isSubscribed: Bool
+    let onSubscribe: () -> Void
+
+    private static let colorPairs: [(Color, Color)] = [
+        (.pink, .orange),
+        (.purple, .blue),
+        (.green, .teal),
+        (.yellow, .orange),
+        (.mint, .green),
+        (.cyan, .indigo),
+        (.red, .pink),
+        (.orange, .pink)
+    ]
+
+    private var gradient: LinearGradient {
+        let pair = Self.colorPairs[abs(result.id) % Self.colorPairs.count]
+        return LinearGradient(
+            colors: [pair.0.opacity(0.2), pair.1.opacity(0.2)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            PodcastArtworkView(
+                artworkURL: result.artworkURL,
+                size: 160,
+                cornerRadius: 16
+            )
+            .shadow(color: .black.opacity(0.2), radius: 6, x: 0, y: 3)
+
+            Text(result.title)
+                .font(.headline)
+                .foregroundColor(.primary)
+                .lineLimit(2)
+                .frame(width: 160, alignment: .leading)
+
+            Button(action: onSubscribe) {
+                Text(isSubscribed ? "Subscribed" : "Subscribe")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(
+                        (isSubscribed ? Color.green : Color.blue)
+                            .opacity(0.2)
+                    )
+                    .foregroundColor(isSubscribed ? .green : .blue)
+                    .cornerRadius(10)
+            }
+            .disabled(isSubscribed)
+        }
+        .padding(8)
+        .background(gradient)
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+        .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+    }
+}
+
+#Preview {
+    LargeRecommendedPodcastItem(
+        result: PodcastSearchResult(
+            id: 1,
+            title: "Sample Podcast",
+            author: "Author",
+            feedURL: URL(string: "https://example.com/feed")!,
+            artworkURL: nil,
+            description: "",
+            genre: "News",
+            trackCount: 0
+        ),
+        isSubscribed: false,
+        onSubscribe: {}
+    )
+}


### PR DESCRIPTION
## Summary
- add `LargeRecommendedPodcastItem` for big artwork cards
- group recommendations by genre in `DiscoverView`
- create `DiscoverGenreSectionView` to show a horizontal list of big cards per genre
- apply a radial gradient background on the Discover page for flair

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_68415403be14832396dbb27a45188933