### PR TITLE
Enable swipe back gesture

### DIFF
--- a/Jimmy/Utilities/SwipeBackHelper.swift
+++ b/Jimmy/Utilities/SwipeBackHelper.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Enables the interactive swipe gesture when using a custom back button.
+struct SwipeBackHelper: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        let controller = UIViewController()
+        controller.view.backgroundColor = .clear
+        DispatchQueue.main.async {
+            controller.navigationController?.interactivePopGestureRecognizer?.delegate = nil
+            controller.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        DispatchQueue.main.async {
+            uiViewController.navigationController?.interactivePopGestureRecognizer?.delegate = nil
+            uiViewController.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+        }
+    }
+}

--- a/Jimmy/Views/EpisodeDetailView.swift
+++ b/Jimmy/Views/EpisodeDetailView.swift
@@ -192,6 +192,7 @@ struct EpisodeDetailView: View {
             .navigationTitle("Episode Details")
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarBackButtonHidden(true)
+            .background(SwipeBackHelper())
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(action: {

--- a/Jimmy/Views/PodcastDetailView.swift
+++ b/Jimmy/Views/PodcastDetailView.swift
@@ -69,6 +69,7 @@ struct PodcastDetailView: View {
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
+        .background(SwipeBackHelper())
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(action: {


### PR DESCRIPTION
## Summary
- fix inability to slide back by re-enabling the interactive pop gesture
- new helper `SwipeBackHelper` enables swipe back gesture when using custom back buttons
- apply helper to EpisodeDetailView and PodcastDetailView

## Testing
- `swift test -c debug`

------
https://chatgpt.com/codex/tasks/task_e_6841547e38908323a8515a75eee3674d