### PR TITLE
Add Apple Podcast share links

### DIFF
--- a/Jimmy/Services/AppleEpisodeLinkService.swift
+++ b/Jimmy/Services/AppleEpisodeLinkService.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+class AppleEpisodeLinkService {
+    static let shared = AppleEpisodeLinkService()
+    private init() {}
+
+    /// Fetch the Apple Podcasts URL for a specific episode by querying the iTunes Search API.
+    /// - Parameters:
+    ///   - episode: Episode object to search for.
+    ///   - podcast: Podcast the episode belongs to.
+    ///   - completion: Callback with optional URL.
+    func fetchAppleLink(for episode: Episode, podcast: Podcast, completion: @escaping (URL?) -> Void) {
+        iTunesSearchService.shared.searchPodcasts(query: podcast.title) { results in
+            let lowerTitle = podcast.title.lowercased()
+            let lowerAuthor = podcast.author.lowercased()
+            guard let match = results.first(where: { res in
+                res.title.lowercased().contains(lowerTitle) || lowerTitle.contains(res.title.lowercased()) ||
+                res.author.lowercased().contains(lowerAuthor) || lowerAuthor.contains(res.author.lowercased())
+            }) else {
+                completion(nil)
+                return
+            }
+
+            iTunesSearchService.shared.searchEpisode(podcastId: match.id, episodeTitle: episode.title) { episodeResult in
+                if let urlString = episodeResult?.trackViewUrl, let url = URL(string: urlString) {
+                    completion(url)
+                } else {
+                    completion(nil)
+                }
+            }
+        }
+    }
+}

--- a/Jimmy/Utilities/ShareSheet.swift
+++ b/Jimmy/Utilities/ShareSheet.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import UIKit
+
+struct ShareSheet: UIViewControllerRepresentable {
+    var items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+        // Nothing to update
+    }
+}

--- a/Jimmy/Views/EpisodeDetailView.swift
+++ b/Jimmy/Views/EpisodeDetailView.swift
@@ -5,6 +5,8 @@ struct EpisodeDetailView: View {
     let podcast: Podcast
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var audioPlayer = AudioPlayerService.shared
+    @State private var shareURL: URL?
+    @State private var showingShareSheet = false
     
     var body: some View {
         NavigationView {
@@ -228,9 +230,9 @@ struct EpisodeDetailView: View {
                         }
                         
                         Divider()
-                        
+
                         Button(action: {
-                            // Share episode (future implementation)
+                            shareEpisode()
                         }) {
                             Label("Share Episode", systemImage: "square.and.arrow.up")
                         }
@@ -242,17 +244,31 @@ struct EpisodeDetailView: View {
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
+        .sheet(isPresented: $showingShareSheet) {
+            if let url = shareURL {
+                ShareSheet(items: [url])
+            }
+        }
     }
-    
+
     private func formatTime(_ timeInterval: TimeInterval) -> String {
         let hours = Int(timeInterval) / 3600
         let minutes = Int(timeInterval.truncatingRemainder(dividingBy: 3600)) / 60
         let seconds = Int(timeInterval.truncatingRemainder(dividingBy: 60))
-        
+
         if hours > 0 {
             return String(format: "%d:%02d:%02d", hours, minutes, seconds)
         } else {
             return String(format: "%d:%02d", minutes, seconds)
+        }
+    }
+
+    private func shareEpisode() {
+        AppleEpisodeLinkService.shared.fetchAppleLink(for: episode, podcast: podcast) { url in
+            if let url = url {
+                shareURL = url
+                showingShareSheet = true
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a simple UIActivityViewController wrapper
- implement `AppleEpisodeLinkService` to retrieve Apple Podcasts URLs
- extend `iTunesSearchService` with podcast episode lookup
- enable sharing from episode row and detail views

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_684159a1772c83239aec328600179ab2