### PR TITLE
Fix document configuration warning

### DIFF
--- a/Jimmy/Info.plist
+++ b/Jimmy/Info.plist
@@ -45,9 +45,11 @@
 	<array>
 		<string>audio</string>
 	</array>
-	<key>UTImportedTypeDeclarations</key>
-	<array>
-		<dict/>
-	</array>
+        <key>UTImportedTypeDeclarations</key>
+        <array>
+                <dict/>
+        </array>
+        <key>LSSupportsOpeningDocumentsInPlace</key>
+        <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- allow opening documents in place by adding LSSupportsOpeningDocumentsInPlace

## Testing
- `swift test --disable-sandbox`


------
https://chatgpt.com/codex/tasks/task_e_6841a9609ea08323a8466ab8caa96669