### PR TITLE
Fix single-URL subscription imports

### DIFF
--- a/Jimmy/Services/SubscriptionImportService.swift
+++ b/Jimmy/Services/SubscriptionImportService.swift
@@ -57,6 +57,17 @@ class SubscriptionImportService {
             .replacingOccurrences(of: "⁩", with: "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         
+        // If the string itself is just a URL, treat it as an RSS/Apple URL
+        if cleanString.hasPrefix("http://") || cleanString.hasPrefix("https://") {
+            // Use host as a placeholder title
+            if let url = URL(string: cleanString) {
+                let hostTitle = url.host ?? cleanString
+                return ParsedPodcast(title: hostTitle, author: "Unknown", appleURL: cleanString)
+            } else {
+                return nil
+            }
+        }
+
         // Extract URL if present (between parentheses)
         var title: String = ""
         var author: String = ""


### PR DESCRIPTION
## Summary
- handle plain RSS URLs when parsing subscription files

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6841c40b96088323a74d3630c2050908