### PR TITLE
Fix swipe back on episode detail

### DIFF
--- a/Jimmy/Views/EpisodeDetailView.swift
+++ b/Jimmy/Views/EpisodeDetailView.swift
@@ -9,8 +9,7 @@ struct EpisodeDetailView: View {
     @State private var showingShareSheet = false
     
     var body: some View {
-        NavigationView {
-            ScrollView {
+        ScrollView {
                 VStack(spacing: 0) {
                     // Header section with episode info
                     VStack(spacing: 16) {
@@ -244,7 +243,6 @@ struct EpisodeDetailView: View {
                 }
             }
         }
-        .navigationViewStyle(StackNavigationViewStyle())
         .sheet(isPresented: $showingShareSheet) {
             if let url = shareURL {
                 ShareSheet(items: [url])


### PR DESCRIPTION
## Summary
- remove nested `NavigationView` from EpisodeDetailView so the main navigation controller handles the interactive pop gesture

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6841ca4416a483238d4d1aa3267a1866