### PR TITLE
Disable pull-to-refresh spinners

### DIFF
--- a/Jimmy/Views/LibraryView.swift
+++ b/Jimmy/Views/LibraryView.swift
@@ -183,11 +183,6 @@ struct LibraryView: View {
                 loadSubscribedPodcasts()
             }
         }
-        .refreshable {
-            loadSubscribedPodcasts()
-            loadAllEpisodesForPodcasts()
-            updateService.forceUpdate()
-        }
         .onChange(of: selectedViewType) {
             // Reset edit mode when switching views
             isEditMode = false

--- a/Jimmy/Views/PodcastDetailView.swift
+++ b/Jimmy/Views/PodcastDetailView.swift
@@ -99,13 +99,6 @@ struct PodcastDetailView: View {
         .onAppear {
             loadEpisodes()
         }
-        .refreshable {
-            await withCheckedContinuation { continuation in
-                loadEpisodes(forceRefresh: true) {
-                    continuation.resume()
-                }
-            }
-        }
     }
     
     private func loadEpisodes(forceRefresh: Bool = false, completion: (() -> Void)? = nil) {

--- a/Jimmy/Views/PodcastListView.swift
+++ b/Jimmy/Views/PodcastListView.swift
@@ -170,9 +170,6 @@ struct PodcastListView: View {
         .onAppear {
             loadSubscribedPodcasts()
         }
-        .refreshable {
-            loadSubscribedPodcasts()
-        }
         .alert("Remove Subscription", isPresented: $showingDeleteAlert) {
             Button("Cancel", role: .cancel) {
                 podcastToDelete = nil

--- a/Jimmy/Views/PodcastSearchView.swift
+++ b/Jimmy/Views/PodcastSearchView.swift
@@ -148,9 +148,6 @@ struct PodcastSearchView: View {
                         .padding(.vertical, 40)
                     }
                 }
-                .refreshable {
-                    await refreshData()
-                }
             }
         }
         .navigationTitle("Search")


### PR DESCRIPTION
## Summary
- remove `.refreshable` modifiers from major views

## Testing
- `./scripts/run_sanity_tests.sh`
- `./scripts/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68428a2d414c8323ac736c24c0f36a10