### PR TITLE
Mark v2 complete with logging and tests

### DIFF
--- a/Jimmy/Utilities/AppLogger.swift
+++ b/Jimmy/Utilities/AppLogger.swift
@@ -1,0 +1,34 @@
+#if canImport(os)
+import os
+#endif
+import Foundation
+
+public enum LogCategory: String {
+    case general
+    case network
+    case storage
+}
+
+public struct AppLogger {
+    #if canImport(os)
+    private static func logger(for category: LogCategory) -> Logger {
+        Logger(subsystem: Bundle.main.bundleIdentifier ?? "Jimmy", category: category.rawValue)
+    }
+
+    public static func info(_ message: String, category: LogCategory = .general) {
+        logger(for: category).info("\(message, privacy: .public)")
+    }
+
+    public static func error(_ message: String, category: LogCategory = .general) {
+        logger(for: category).error("\(message, privacy: .public)")
+    }
+    #else
+    public static func info(_ message: String, category: LogCategory = .general) {
+        print("[\(category.rawValue)] \(message)")
+    }
+
+    public static func error(_ message: String, category: LogCategory = .general) {
+        print("[\(category.rawValue)] ERROR: \(message)")
+    }
+    #endif
+}

--- a/Jimmy/Utilities/DebugHelper.swift
+++ b/Jimmy/Utilities/DebugHelper.swift
@@ -25,10 +25,10 @@ class DebugHelper {
                 try fileManager.removeItem(at: url)
             }
         } catch {
-            print("Error clearing documents directory: \(error)")
+            AppLogger.error("Error clearing documents directory: \(error)")
         }
-        
-        print("All app data reset successfully")
+
+        AppLogger.info("All app data reset successfully")
     }
     
     // Send test notification
@@ -41,9 +41,9 @@ class DebugHelper {
         let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request) { error in
             if let error = error {
-                print("Error sending test notification: \(error)")
+                AppLogger.error("Error sending test notification: \(error)")
             } else {
-                print("Test notification sent successfully")
+                AppLogger.info("Test notification sent successfully")
             }
         }
     }
@@ -53,10 +53,10 @@ class DebugHelper {
         let podcasts = PodcastService.shared.loadPodcasts()
         let queue = QueueViewModel.shared.queue
         
-        print("=== Jimmy App State ===")
-        print("Podcasts: \(podcasts.count)")
-        print("Queue episodes: \(queue.count)")
-        print("Settings: darkMode = \(UserDefaults.standard.bool(forKey: "darkMode"))")
-        print("========================")
+        AppLogger.info("=== Jimmy App State ===")
+        AppLogger.info("Podcasts: \(podcasts.count)")
+        AppLogger.info("Queue episodes: \(queue.count)")
+        AppLogger.info("Settings: darkMode = \(UserDefaults.standard.bool(forKey: \"darkMode\"))")
+        AppLogger.info("========================")
     }
 } 

--- a/Jimmy/Utilities/FileStorage.swift
+++ b/Jimmy/Utilities/FileStorage.swift
@@ -28,10 +28,10 @@ class FileStorage {
         do {
             let data = try JSONEncoder().encode(object)
             try data.write(to: url)
-            print("💾 Saved \(filename) (\(data.count) bytes)")
+            AppLogger.info("💾 Saved \(filename) (\(data.count) bytes)", category: .storage)
             return true
         } catch {
-            print("❌ Failed to save \(filename): \(error.localizedDescription)")
+            AppLogger.error("❌ Failed to save \(filename): \(error.localizedDescription)", category: .storage)
             return false
         }
     }
@@ -47,10 +47,10 @@ class FileStorage {
         do {
             let data = try Data(contentsOf: url)
             let object = try JSONDecoder().decode(type, from: data)
-            print("📱 Loaded \(filename) (\(data.count) bytes)")
+            AppLogger.info("📱 Loaded \(filename) (\(data.count) bytes)", category: .storage)
             return object
         } catch {
-            print("❌ Failed to load \(filename): \(error.localizedDescription)")
+            AppLogger.error("❌ Failed to load \(filename): \(error.localizedDescription)", category: .storage)
             return nil
         }
     }
@@ -65,10 +65,10 @@ class FileStorage {
         
         do {
             try fileManager.removeItem(at: url)
-            print("🗑️ Deleted \(filename)")
+            AppLogger.info("🗑️ Deleted \(filename)", category: .storage)
             return true
         } catch {
-            print("❌ Failed to delete \(filename): \(error.localizedDescription)")
+            AppLogger.error("❌ Failed to delete \(filename): \(error.localizedDescription)", category: .storage)
             return false
         }
     }
@@ -112,7 +112,7 @@ class FileStorage {
         if save(object, to: filename) {
             // Clear from UserDefaults to free up space
             UserDefaults.standard.removeObject(forKey: userDefaultsKey)
-            print("📦 Migrated \(userDefaultsKey) from UserDefaults to file storage")
+            AppLogger.info("📦 Migrated \(userDefaultsKey) from UserDefaults to file storage", category: .storage)
             return object
         }
         

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
             path: "Jimmy/Utilities",
             sources: [
                 "FileStorage.swift",
+                "AppLogger.swift",
                 "SpotifyListParser.swift",
                 "UserDataService.swift",
                 "../Models/Podcast.swift"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ A minimalist, queue-centric iOS podcast app inspired by Google Podcasts with enh
 - 💫 **Watch connectivity implemented** for playback control
 - 📋 **Instructions** in `Jimmy/WATCH_README.md`
 
+## Development Roadmap
+
+Work on **Version 2 – Stability Improvements** is now complete. All five phases
+have shipped, and the release is fully stabilized. See
+[versions/v2.md](versions/v2.md) for the final checklist and notes.
+
 ## Overview
 Jimmy is a personal podcast app for iPhone, designed for simplicity, speed, and a queue-focused listening experience. It allows you to import your podcast subscriptions, discover and manage shows, and listen to episodes with a clean, modern interface. The app includes a beautiful lock-screen widget that matches your wireframe design for seamless playback control.
 
@@ -153,6 +159,7 @@ Jimmy/
 - **Watch Status**: Connectivity implemented, Xcode setup required
 - **Build Issues**: All resolved, main app builds successfully
 - **Repository**: Published and updated on GitHub
+- **Release Notes**: See [versions/v2_release_notes.md](versions/v2_release_notes.md)
 
 ## 🤝 Collaboration & Project Rules
 

--- a/Tests/JimmyTests/EpisodeCacheServiceTests.swift
+++ b/Tests/JimmyTests/EpisodeCacheServiceTests.swift
@@ -42,6 +42,23 @@ final class EpisodeCacheServiceTests: XCTestCase {
         wait(for: [exp], timeout: 1)
         XCTAssertEqual(StubURLProtocol.requestCount, 1)
     }
+
+    func testNetworkFailureUsesStaleCache() {
+        let podcast = Podcast(title: "Test", author: "A", feedURL: URL(string: "https://example.com/feed")!)
+        let episodes = [Episode(id: UUID(), title: "Ep", artworkURL: nil, audioURL: URL(string: "https://a.com/1.mp3"), description: nil, played: false, podcastID: podcast.id, publishedDate: nil, localFileURL: nil, playbackPosition: 0)]
+        EpisodeCacheService.shared.clearAllCache()
+        EpisodeCacheService.shared.insertCache(episodes: episodes, for: podcast.id, timestamp: Date(timeIntervalSinceNow: -3600))
+        StubURLProtocol.requestCount = 0
+        StubURLProtocol.error = NSError(domain: NSURLErrorDomain, code: -1009, userInfo: nil)
+        let exp = expectation(description: "callback")
+        EpisodeCacheService.shared.getEpisodes(for: podcast) { result in
+            XCTAssertEqual(result.count, episodes.count)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(StubURLProtocol.requestCount, 1)
+        StubURLProtocol.error = nil
+    }
 }
 
 final class StubURLProtocol: URLProtocol {
@@ -51,11 +68,18 @@ final class StubURLProtocol: URLProtocol {
     <rss><channel><item><title>Ep</title><enclosure url="https://a.com/1.mp3" type="audio/mpeg"/></item></channel></rss>
     """.data(using: .utf8)!
 
+    static var responseCode: Int = 200
+    static var error: Error?
+
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
     override func startLoading() {
         Self.requestCount += 1
-        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        if let error = Self.error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        let response = HTTPURLResponse(url: request.url!, statusCode: Self.responseCode, httpVersion: nil, headerFields: nil)!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: Self.stubData)
         client?.urlProtocolDidFinishLoading(self)

--- a/versions/v2.md
+++ b/versions/v2.md
@@ -23,5 +23,6 @@ This release focuses entirely on making Jimmy more reliable. To organize the wor
 - **Ensure caching falls back gracefully** when disk space is low or data is missing.
 
 ## Phase 5 – Final Polish
-- **Review instrumentation and tests** and stabilize the release.
-- **Update documentation and release notes** with any final guidance.
+**⭐ Completed**
+- [x] Review instrumentation and tests and stabilize the release.
+- [x] Update documentation and release notes with any final guidance.

--- a/versions/v2_release_notes.md
+++ b/versions/v2_release_notes.md
@@ -1,0 +1,11 @@
+# Version 2 Release Notes
+
+Jimmy 2 focuses entirely on reliability and performance. Major improvements include:
+
+- Lock-screen widget isolation and App Groups data sharing
+- Expanded automated test coverage and continuous integration
+- Robust error logging and network recovery
+- Optimized file storage with corruption checks
+- Numerous bug fixes and UI polish
+
+This update prepares the project for wider testing and distribution. For details on each phase see [v2.md](v2.md).


### PR DESCRIPTION
## Summary
- stabilize version 2 by completing phase 5 tasks
- add `AppLogger` and swap print calls for structured logs
- expand episode cache tests for network failure
- finalize documentation with release notes

## Testing
- `./scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842940af23c8323abdd00a91c39b50a