### PR TITLE
Complete unit test coverage

### DIFF
--- a/Jimmy/Utilities/OPMLParser.swift
+++ b/Jimmy/Utilities/OPMLParser.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
 
 class OPMLParser: NSObject, XMLParserDelegate {
     private var podcasts: [Podcast] = []

--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,16 @@ let package = Package(
     targets: [
         .target(
             name: "JimmyUtilities",
-            path: "Jimmy/Utilities",
+            path: "Jimmy",
             sources: [
-                "FileStorage.swift",
-                "SpotifyListParser.swift",
-                "UserDataService.swift",
-                "../Models/Podcast.swift"
+                "Utilities/FileStorage.swift",
+                "Utilities/SpotifyListParser.swift",
+                "Utilities/UserDataService.swift",
+                "Utilities/AppleBulkImportParser.swift",
+                "Utilities/GoogleTakeoutParser.swift",
+                "Utilities/OPMLParser.swift",
+                "Utilities/StringExtensions.swift",
+                "Models/Podcast.swift"
             ]
         ),
         .testTarget(

--- a/Tests/JimmyTests/AppleBulkImportParserTests.swift
+++ b/Tests/JimmyTests/AppleBulkImportParserTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import JimmyUtilities
+
+final class AppleBulkImportParserTests: XCTestCase {
+    func testParseValidJSON() throws {
+        let json = """
+        [
+            {"title": "Show1", "feedUrl": "https://example.com/1.xml", "author": "A"},
+            {"title": "Show2", "feedUrl": "https://example.com/2.xml"}
+        ]
+        """
+        let data = Data(json.utf8)
+        let podcasts = try AppleBulkImportParser.parse(data: data)
+        XCTAssertEqual(podcasts.count, 2)
+        XCTAssertEqual(podcasts[0].title, "Show1")
+        XCTAssertEqual(podcasts[1].author, "")
+    }
+}

--- a/Tests/JimmyTests/EpisodeCacheStatsTests.swift
+++ b/Tests/JimmyTests/EpisodeCacheStatsTests.swift
@@ -1,0 +1,20 @@
+#if !os(Linux)
+import XCTest
+@testable import Jimmy
+
+final class EpisodeCacheStatsTests: XCTestCase {
+    override func setUp() async throws {
+        EpisodeCacheService.shared.clearAllCache()
+    }
+
+    func testGetCacheStatsCountsEntries() {
+        let podcastID = UUID()
+        let episode = Episode(id: UUID(), title: "Test", artworkURL: nil, audioURL: nil, description: nil, played: false, podcastID: podcastID, publishedDate: nil, localFileURL: nil)
+        EpisodeCacheService.shared.insertCache(episodes: [episode], for: podcastID)
+        let stats = EpisodeCacheService.shared.getCacheStats()
+        XCTAssertEqual(stats.totalPodcasts, 1)
+        XCTAssertEqual(stats.freshEntries, 1)
+        XCTAssertEqual(stats.expiredEntries, 0)
+    }
+}
+#endif

--- a/Tests/JimmyTests/EpisodeViewModelTests.swift
+++ b/Tests/JimmyTests/EpisodeViewModelTests.swift
@@ -1,0 +1,35 @@
+#if !os(Linux)
+import XCTest
+@testable import Jimmy
+
+final class EpisodeViewModelTests: XCTestCase {
+    override func setUp() async throws {
+        EpisodeViewModel.shared.clearAllEpisodes()
+    }
+
+    func testAddEpisodesDeduplicatesByTitle() {
+        let podcastID = UUID()
+        let e1 = Episode(id: UUID(), title: "Ep", artworkURL: nil, audioURL: nil, description: nil, played: false, podcastID: podcastID, publishedDate: nil, localFileURL: nil)
+        let e2 = Episode(id: UUID(), title: "Ep", artworkURL: nil, audioURL: nil, description: nil, played: false, podcastID: podcastID, publishedDate: nil, localFileURL: nil)
+
+        EpisodeViewModel.shared.addEpisodes([e1])
+        EpisodeViewModel.shared.addEpisodes([e2])
+
+        let episodes = EpisodeViewModel.shared.getEpisodes(for: podcastID)
+        XCTAssertEqual(episodes.count, 1)
+        XCTAssertEqual(episodes.first?.id, e1.id)
+    }
+
+    func testMarkAllEpisodesAsPlayed() {
+        let podcastID = UUID()
+        let e1 = Episode(id: UUID(), title: "A", artworkURL: nil, audioURL: nil, description: nil, played: false, podcastID: podcastID, publishedDate: nil, localFileURL: nil)
+        let e2 = Episode(id: UUID(), title: "B", artworkURL: nil, audioURL: nil, description: nil, played: false, podcastID: podcastID, publishedDate: nil, localFileURL: nil)
+
+        EpisodeViewModel.shared.addEpisodes([e1, e2])
+        EpisodeViewModel.shared.markAllEpisodesAsPlayed(for: podcastID)
+
+        let playedCount = EpisodeViewModel.shared.getPlayedEpisodesCount(for: podcastID)
+        XCTAssertEqual(playedCount, 2)
+    }
+}
+#endif

--- a/Tests/JimmyTests/GoogleTakeoutParserTests.swift
+++ b/Tests/JimmyTests/GoogleTakeoutParserTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import JimmyUtilities
+
+final class GoogleTakeoutParserTests: XCTestCase {
+    func testParseSubscriptions() throws {
+        let json = """
+        {"subscriptions": [
+            {"title": "Show1", "feedUrl": "https://example.com/1.xml"},
+            {"title": "Show2", "feedUrl": "https://example.com/2.xml"}
+        ]}
+        """
+        let data = Data(json.utf8)
+        let podcasts = try GoogleTakeoutParser.parse(data: data)
+        XCTAssertEqual(podcasts.count, 2)
+        XCTAssertEqual(podcasts.first?.title, "Show1")
+    }
+}

--- a/Tests/JimmyTests/OPMLParserTests.swift
+++ b/Tests/JimmyTests/OPMLParserTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import JimmyUtilities
+
+final class OPMLParserTests: XCTestCase {
+    func testParseOPMLFile() throws {
+        let opml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <opml version="1.1">
+            <body>
+                <outline text="Show1" xmlUrl="https://example.com/1.xml" />
+                <outline text="Show2" xmlUrl="https://example.com/2.xml" author="Author" />
+            </body>
+        </opml>
+        """
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent("test.opml")
+        try opml.write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let parser = OPMLParser()
+        let podcasts = parser.parseOPML(from: fileURL)
+        XCTAssertEqual(podcasts.count, 2)
+        XCTAssertEqual(podcasts[0].title, "Show1")
+        XCTAssertEqual(podcasts[1].author, "Author")
+    }
+}

--- a/Tests/JimmyTests/QueueViewModelTests.swift
+++ b/Tests/JimmyTests/QueueViewModelTests.swift
@@ -1,0 +1,26 @@
+#if !os(Linux)
+import XCTest
+@testable import Jimmy
+
+final class QueueViewModelTests: XCTestCase {
+    override func setUp() async throws {
+        QueueViewModel.shared.queue.removeAll()
+    }
+
+    func testAddToQueuePreventsDuplicates() {
+        let episode = Episode(id: UUID(), title: "Ep", artworkURL: nil, audioURL: nil, description: nil, played: false, podcastID: nil, publishedDate: nil, localFileURL: nil)
+        QueueViewModel.shared.addToQueue(episode)
+        QueueViewModel.shared.addToQueue(episode)
+        XCTAssertEqual(QueueViewModel.shared.queue.count, 1)
+    }
+
+    func testMoveToEndOfQueue() {
+        let e1 = Episode(id: UUID(), title: "1", artworkURL: nil, audioURL: nil, description: nil, played: false, podcastID: nil, publishedDate: nil, localFileURL: nil)
+        let e2 = Episode(id: UUID(), title: "2", artworkURL: nil, audioURL: nil, description: nil, played: false, podcastID: nil, publishedDate: nil, localFileURL: nil)
+        QueueViewModel.shared.addToQueue(e1)
+        QueueViewModel.shared.addToQueue(e2)
+        QueueViewModel.shared.moveToEndOfQueue(e1)
+        XCTAssertEqual(QueueViewModel.shared.queue.last?.id, e1.id)
+    }
+}
+#endif

--- a/Tests/JimmyTests/StringExtensionsTests.swift
+++ b/Tests/JimmyTests/StringExtensionsTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import JimmyUtilities
+
+final class StringExtensionsTests: XCTestCase {
+    func testCleanedEpisodeDescription() {
+        let html = "<p>Hello &amp; welcome to <b>the show</b>!\n</p>"
+        let cleaned = html.cleanedEpisodeDescription
+        XCTAssertEqual(cleaned, "Hello & welcome to the show!")
+    }
+}


### PR DESCRIPTION
## Summary
- add parser tests for AppleBulkImportParser, GoogleTakeoutParser, and OPMLParser
- verify description cleaning logic in StringExtensions
- include new parser files in the Swift package
- import FoundationXML for OPMLParser under SPM

## Testing
- `./scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684293f924bc83238c1dde4ad4979134