### PR TITLE
Enable playback speed setting

### DIFF
--- a/Jimmy/Views/SettingsView.swift
+++ b/Jimmy/Views/SettingsView.swift
@@ -52,6 +52,9 @@ struct SettingsView: View {
                         Text("2x").tag(2.0)
                     }
                     .pickerStyle(MenuPickerStyle())
+                    .onChange(of: playbackSpeed) { newValue in
+                        AudioPlayerService.shared.updatePlaybackSpeed(newValue)
+                    }
                 }
             }
             Section(header: Text("Appearance")) {
@@ -222,6 +225,9 @@ struct SettingsView: View {
             }
         }
         .navigationTitle("Settings")
+        .onAppear {
+            AudioPlayerService.shared.updatePlaybackSpeed(playbackSpeed)
+        }
         .fileExporter(isPresented: $isExporting, document: AppDataDocument(), contentType: .json, defaultFilename: "JimmyBackup") { result in
             if case .failure(let error) = result {
                 importError = error.localizedDescription


### PR DESCRIPTION
## Summary
- connect playback speed picker to AudioPlayerService
- load and store playback speed in AudioPlayerService
- apply selected speed whenever episodes play
- update now-playing info to show current speed

## Testing
- `swift build -c release`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68434ebd91608323a240809821f8cebd