### PR TITLE
Add trending, featured and top charts to discovery

### DIFF
--- a/Jimmy/Services/DiscoveryService.swift
+++ b/Jimmy/Services/DiscoveryService.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+struct TrendingEpisode: Identifiable {
+    let id: Int
+    let title: String
+    let podcastName: String
+    let feedURL: URL
+    let artworkURL: URL?
+}
+
+/// Service responsible for fetching top charts, featured podcasts and trending episodes
+class DiscoveryService {
+    static let shared = DiscoveryService()
+    private init() {}
+
+    private let baseURL = "https://rss.applemarketingtools.com/api/v2/us/podcasts"
+
+    func fetchTopCharts(limit: Int = 100, completion: @escaping ([PodcastSearchResult]) -> Void) {
+        let url = URL(string: "\(baseURL)/top/\(limit)/podcasts.json")!
+        fetchChart(url: url, completion: completion)
+    }
+
+    func fetchFeaturedPodcasts(limit: Int = 20, completion: @escaping ([PodcastSearchResult]) -> Void) {
+        let url = URL(string: "\(baseURL)/top/\(limit)/podcasts.json")!
+        fetchChart(url: url, completion: completion)
+    }
+
+    func fetchTrendingEpisodes(limit: Int = 10, completion: @escaping ([TrendingEpisode]) -> Void) {
+        let url = URL(string: "\(baseURL)/top/\(limit)/podcasts.json")!
+        NetworkManager.shared.fetchData(with: URLRequest(url: url)) { result in
+            guard case let .success(data) = result else {
+                DispatchQueue.main.async { completion([]) }
+                return
+            }
+            guard let response = try? JSONDecoder().decode(AppleTopChartResponse.self, from: data) else {
+                DispatchQueue.main.async { completion([]) }
+                return
+            }
+            let ids = response.feed.results.compactMap { Int($0.id) }
+            let group = DispatchGroup()
+            var episodes: [TrendingEpisode] = []
+            for id in ids {
+                group.enter()
+                self.fetchLatestEpisode(for: id) { episode in
+                    if let episode = episode { episodes.append(episode) }
+                    group.leave()
+                }
+            }
+            group.notify(queue: .main) {
+                completion(episodes)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+    private func fetchChart(url: URL, completion: @escaping ([PodcastSearchResult]) -> Void) {
+        NetworkManager.shared.fetchData(with: URLRequest(url: url)) { result in
+            guard case let .success(data) = result else {
+                DispatchQueue.main.async { completion([]) }
+                return
+            }
+            guard let response = try? JSONDecoder().decode(AppleTopChartResponse.self, from: data) else {
+                DispatchQueue.main.async { completion([]) }
+                return
+            }
+            let ids = response.feed.results.compactMap { Int($0.id) }
+            self.lookupPodcasts(ids: ids, completion: completion)
+        }
+    }
+
+    private func lookupPodcasts(ids: [Int], completion: @escaping ([PodcastSearchResult]) -> Void) {
+        guard !ids.isEmpty else { completion([]); return }
+        let idString = ids.map(String.init).joined(separator: ",")
+        let urlString = "https://itunes.apple.com/lookup?id=\(idString)&entity=podcast"
+        guard let url = URL(string: urlString) else { completion([]); return }
+        NetworkManager.shared.fetchData(with: URLRequest(url: url)) { result in
+            guard case let .success(data) = result,
+                  let lookup = try? JSONDecoder().decode(iTunesSearchResponse.self, from: data) else {
+                DispatchQueue.main.async { completion([]) }
+                return
+            }
+            let results = lookup.results.compactMap { item -> PodcastSearchResult? in
+                guard let feedUrlStr = item.feedUrl,
+                      let feedURL = URL(string: feedUrlStr) else { return nil }
+                return PodcastSearchResult(
+                    id: item.collectionId,
+                    title: item.collectionName,
+                    author: item.artistName,
+                    feedURL: feedURL,
+                    artworkURL: URL(string: item.artworkUrl600 ?? item.artworkUrl100 ?? ""),
+                    description: item.description,
+                    genre: item.primaryGenreName,
+                    trackCount: item.trackCount
+                )
+            }
+            DispatchQueue.main.async { completion(results) }
+        }
+    }
+
+    private func fetchLatestEpisode(for podcastId: Int, completion: @escaping (TrendingEpisode?) -> Void) {
+        let urlString = "https://itunes.apple.com/lookup?id=\(podcastId)&entity=podcastEpisode&limit=1"
+        guard let url = URL(string: urlString) else { completion(nil); return }
+        NetworkManager.shared.fetchData(with: URLRequest(url: url)) { result in
+            guard case let .success(data) = result,
+                  let lookup = try? JSONDecoder().decode(iTunesEpisodeLookupResponse.self, from: data),
+                  lookup.results.count > 1 else {
+                DispatchQueue.main.async { completion(nil) }
+                return
+            }
+            let podcast = lookup.results[0]
+            let episode = lookup.results[1]
+            guard let feedUrl = podcast.feedUrl, let feedURL = URL(string: feedUrl) else {
+                DispatchQueue.main.async { completion(nil) }
+                return
+            }
+            let episodeItem = TrendingEpisode(
+                id: episode.trackId,
+                title: episode.trackName,
+                podcastName: podcast.collectionName,
+                feedURL: feedURL,
+                artworkURL: URL(string: episode.artworkUrl600 ?? episode.artworkUrl100 ?? podcast.artworkUrl600 ?? podcast.artworkUrl100 ?? "")
+            )
+            DispatchQueue.main.async { completion(episodeItem) }
+        }
+    }
+}
+
+private struct AppleTopChartResponse: Codable {
+    let feed: AppleFeed
+}
+
+private struct AppleFeed: Codable {
+    let results: [ApplePodcastChartItem]
+}
+
+private struct ApplePodcastChartItem: Codable {
+    let id: String
+}
+
+private struct iTunesEpisodeLookupResponse: Codable {
+    let results: [iTunesEpisodeLookupItem]
+}
+
+private struct iTunesEpisodeLookupItem: Codable {
+    let collectionName: String
+    let trackId: Int
+    let trackName: String
+    let feedUrl: String?
+    let artworkUrl100: String?
+    let artworkUrl600: String?
+}

--- a/Jimmy/Views/TopChartRowView.swift
+++ b/Jimmy/Views/TopChartRowView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct TopChartRowView: View {
+    let index: Int
+    let result: PodcastSearchResult
+    let isSubscribed: Bool
+    let onSubscribe: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text("\(index)")
+                .font(.title3.bold())
+                .frame(width: 30, alignment: .center)
+                .foregroundColor(.secondary)
+
+            PodcastArtworkView(
+                artworkURL: result.artworkURL,
+                size: 60,
+                cornerRadius: 8
+            )
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(result.title)
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                    .lineLimit(2)
+                Text(result.author)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Button(action: onSubscribe) {
+                Text(isSubscribed ? "Subscribed" : "Subscribe")
+                    .font(.caption)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background((isSubscribed ? Color.green : Color.blue).opacity(0.2))
+                    .foregroundColor(isSubscribed ? .green : .blue)
+                    .cornerRadius(8)
+            }
+            .disabled(isSubscribed)
+        }
+        .padding(.horizontal)
+    }
+}
+
+#Preview {
+    TopChartRowView(
+        index: 1,
+        result: PodcastSearchResult(
+            id: 1,
+            title: "Sample Podcast",
+            author: "Author",
+            feedURL: URL(string: "https://example.com/feed")!,
+            artworkURL: nil,
+            description: nil,
+            genre: "News",
+            trackCount: 0
+        ),
+        isSubscribed: false,
+        onSubscribe: {}
+    )
+}

--- a/Jimmy/Views/TrendingEpisodeItemView.swift
+++ b/Jimmy/Views/TrendingEpisodeItemView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct TrendingEpisodeItemView: View {
+    let episode: TrendingEpisode
+    let onSubscribe: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            PodcastArtworkView(
+                artworkURL: episode.artworkURL,
+                size: 160,
+                cornerRadius: 12
+            )
+            .shadow(color: .black.opacity(0.25), radius: 6, x: 0, y: 4)
+
+            Text(episode.title)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .lineLimit(2)
+                .foregroundColor(.primary)
+                .frame(width: 160, alignment: .leading)
+
+            Text(episode.podcastName)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .frame(width: 160, alignment: .leading)
+
+            Button(action: onSubscribe) {
+                Text("Subscribe")
+                    .font(.caption2)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.blue.opacity(0.2))
+                    .foregroundColor(.blue)
+                    .cornerRadius(8)
+            }
+        }
+        .padding(8)
+    }
+}
+
+#Preview {
+    TrendingEpisodeItemView(
+        episode: TrendingEpisode(
+            id: 1,
+            title: "Sample Episode",
+            podcastName: "Podcast Name",
+            feedURL: URL(string: "https://example.com/feed")!,
+            artworkURL: nil
+        ),
+        onSubscribe: {}
+    )
+}


### PR DESCRIPTION
## Summary
- add `DiscoveryService` to fetch top podcasts and trending episodes
- show new sections in `DiscoverView`
- add `TrendingEpisodeItemView` and `TopChartRowView`

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_68467167cd5083239fdafd33dbc80bd5